### PR TITLE
Add Pirsch Analytics

### DIFF
--- a/src/pages/google-analytics-alternatives.js
+++ b/src/pages/google-analytics-alternatives.js
@@ -97,6 +97,15 @@ const tableData = [
     cloudHosting: true,
     selfHosting: true,
   },
+  {
+    company: "Pirsch Analytics",
+    url: "https://pirsch.io/",
+    description: "Pirsch is simple, privacy-friendly, open-source web analytics — lightweight, cookie-free and easily integrated into any website or backend.",
+    permissiveOpenSource: false,
+    copyleftOpenSource: true,
+    cloudHosting: true,
+    selfHosting: false,
+  },
 ];
 
 const Extra = () => {


### PR DESCRIPTION
Hi, I've added [Pirsch](https://pirsch.io) as an alternative to GA to the list. I'm one of the co-founders :)