### PR TITLE
Misleading information about PostHog Cloud

### DIFF
--- a/src/pages/alternatives.js
+++ b/src/pages/alternatives.js
@@ -49,7 +49,7 @@ const tableData = [
       "Website analytics, product analytics, experimentation, session recording, feature flags, plugins, warehouse-compatible",
     permissiveOpenSource: true,
     copyleftOpenSource: false,
-    cloudHosting: true,
+    cloudHosting: false,
     selfHosting: true,
   },
   {


### PR DESCRIPTION
PostHog Cloud is provided by an US entity and therefore is bound by the same Cloud Act as Google Analytics. Therefore saying that PostHog Cloud would be a safer alternative to Google Analytics is misleading, to say the least.