### PR TITLE
Add Counter.dev as an alternative

### DIFF
--- a/src/pages/alternatives.js
+++ b/src/pages/alternatives.js
@@ -179,6 +179,15 @@ const tableData = [
     cloudHosting: true,
     selfHosting: false,
   },
+  {
+    company: "Counter",
+    url: "https://counter.dev",
+    description: "Simple and Privacy-friendly web analytics (No Cookies, logging, IPs)",
+    permissiveOpenSource: false,
+    copyleftOpenSource: true,
+    cloudHosting: true,
+    selfHosting: true,
+  },
 ];
 
 const Extra = () => {


### PR DESCRIPTION
I am adding Counter.dev as an alternative, as I have been using it lately and I noticed that it is not being featured here.

Sources:
 - Website: https://counter.dev/
 - GitHub: https://github.com/ihucos/counter.dev