### PR TITLE
(improvement) Set cloud hosting location for Swetrix

### DIFF
--- a/src/pages/alternatives.js
+++ b/src/pages/alternatives.js
@@ -221,6 +221,7 @@ const tableData = [
     permissiveOpenSource: false,
     copyleftOpenSource: true,
     cloudHosting: true,
+    cloudHostingLocation: "EU",
     selfHosting: true,
   },
   {


### PR DESCRIPTION
Swetrix Cloud is hosted in Nuremberg, Germany (EU).