### PR TITLE
Add Databuddy to Google Analytics alternatives table

### DIFF
--- a/src/pages/alternatives.js
+++ b/src/pages/alternatives.js
@@ -150,6 +150,16 @@ const tableData = [
     selfHosting: false,
   },
   {
+    company: "Databuddy",
+    url: "https://databuddy.cc/",
+    description:
+      "Lightweight Privacy-first Analytics for Developers",
+    permissiveOpenSource: false,
+    copyleftOpenSource: true,
+    cloudHosting: true,
+    selfHosting: true,
+  },
+  {
     company: "TelemetryDeck",
     url: "https://telemetrydeck.com/",
     description: "100% anonymized analytics for apps and websites",

--- a/src/pages/alternatives.js
+++ b/src/pages/alternatives.js
@@ -157,6 +157,7 @@ const tableData = [
     permissiveOpenSource: false,
     copyleftOpenSource: true,
     cloudHosting: true,
+    cloudHostingLocation: "EU",
     selfHosting: true,
   },
   {


### PR DESCRIPTION
Databuddy is a privacy-first analytics option with cloud and self-hosted deployments, listed alongside other alternatives on the alternatives page.